### PR TITLE
fix: panel toggle keybind

### DIFF
--- a/lua/tide/api.lua
+++ b/lua/tide/api.lua
@@ -84,7 +84,7 @@ M.attach_mappings = function()
   -- set basic mapping
   vim.keymap.set(
     "n",
-    state.options.keys.leader .. state.options.keys.leader,
+    state.options.keys.leader .. state.options.keys.panel,
     M.toggle_panel,
     { noremap = true, silent = true, desc = "tide panel" }
   )


### PR DESCRIPTION
The panel toggle keybind was accidentally using the leader key value 2 times. For the example in the readme this works since the leader and the toggle were the same keybind. But for a config such as

```lua
{
  keys = {
    leader = '<leader>m',
    panel = ';'
  }
}
```

You wouldn't be able to get `<leader>m;` to register.