### PR TITLE
doc: fix lazy.nvim example 'requires'->'dependencies'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The UI design of Tide.nvim is inspired by/based on [menu.nvim](https://github.co
       -- optional configuration
     })
   end,
-  requires = {
+  dependencies = {
     "MunifTanjim/nui.nvim",
     "nvim-tree/nvim-web-devicons"
   }

--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ The UI design of Tide.nvim is inspired by/based on [menu.nvim](https://github.co
 ```lua
 {
   "jackMort/tide.nvim",
-  config = function()
-    require("tide").setup({
+  opts = {
       -- optional configuration
-    })
-  end,
+  },
   dependencies = {
     "MunifTanjim/nui.nvim",
     "nvim-tree/nvim-web-devicons"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The UI design of Tide.nvim is inspired by/based on [menu.nvim](https://github.co
       -- optional configuration
     })
   end,
-  dependencies = {
+  requires = {
     "MunifTanjim/nui.nvim",
     "nvim-tree/nvim-web-devicons"
   }


### PR DESCRIPTION
Lazy.nvim uses `dependencies`, not `requires`.
See: https://lazy.folke.io/spec#spec-loading