### PR TITLE
fix: fix: keeping order of tags within the panel

### DIFF
--- a/lua/tide/render.lua
+++ b/lua/tide/render.lua
@@ -29,9 +29,11 @@ M.render = function()
 
   local unique_names = utils.generate_unique_names(files)
 
-  for tag, file in pairs(state.current_state.tags) do
-    state.current_state.tags[tag] = file
-    M.render_file(utils.get_icon(file), unique_names[file], tag)
+  for letter in state.options.hints.dictionary:gmatch(".") do
+    local file = state.current_state.tags[letter]
+    if file then
+      M.render_file(utils.get_icon(file), unique_names[file], letter)
+    end
   end
 
   for _ = state.current_state.linenr, state.current_state.height - MENU_HEIGHT do


### PR DESCRIPTION
Due to lua pairs doesn't keep the order of the elements, the tags list within the panel didn't keep the order properly.

This PR fix that, iterating by the letters of the dictionary and printing the tags keeping the order.

Before
<img width="1192" alt="SCR-20241204-gvfd" src="https://github.com/user-attachments/assets/6a4c7888-1141-4202-b28c-c7846f587600">

After
<img width="1175" alt="SCR-20241204-gwjt" src="https://github.com/user-attachments/assets/1d90ed9a-b7f7-458b-b6b2-40be00d170a8">
